### PR TITLE
add int cast to bytes_read

### DIFF
--- a/ext/nio4r/bytebuffer.c
+++ b/ext/nio4r/bytebuffer.c
@@ -335,7 +335,7 @@ static VALUE NIO_ByteBuffer_write_to(VALUE self, VALUE io)
 
     buffer->position += bytes_written;
 
-    return INT2NUM(bytes_written);
+    return INT2NUM((int)bytes_written);
 }
 
 static VALUE NIO_ByteBuffer_flip(VALUE self)

--- a/ext/nio4r/bytebuffer.c
+++ b/ext/nio4r/bytebuffer.c
@@ -305,7 +305,7 @@ static VALUE NIO_ByteBuffer_read_from(VALUE self, VALUE io)
 
     buffer->position += bytes_read;
 
-    return INT2NUM(bytes_read);
+    return INT2NUM((int)bytes_read);
 }
 
 static VALUE NIO_ByteBuffer_write_to(VALUE self, VALUE io)

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -182,7 +182,7 @@ static VALUE NIO_Monitor_add_interest(VALUE self, VALUE interest)
     Data_Get_Struct(self, struct NIO_Monitor, monitor);
 
     interest = monitor->interests | NIO_Monitor_symbol2interest(interest);
-    NIO_Monitor_update_interests(self, interest);
+    NIO_Monitor_update_interests(self, (int)interest);
 
     return rb_ivar_get(self, rb_intern("interests"));
 }
@@ -193,7 +193,7 @@ static VALUE NIO_Monitor_remove_interest(VALUE self, VALUE interest)
     Data_Get_Struct(self, struct NIO_Monitor, monitor);
 
     interest = monitor->interests & ~NIO_Monitor_symbol2interest(interest);
-    NIO_Monitor_update_interests(self, interest);
+    NIO_Monitor_update_interests(self, (int)interest);
 
     return rb_ivar_get(self, rb_intern("interests"));
 }

--- a/lib/nio/version.rb
+++ b/lib/nio/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NIO
-  VERSION = "2.5.9"
+  VERSION = "2.6.0"
 end


### PR DESCRIPTION
```zsh
compiling bytebuffer.c
bytebuffer.c:308:20: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
    return INT2NUM(bytes_read);
           ~~~~~~~ ^~~~~~~~~~
bytebuffer.c:338:20: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
    return INT2NUM(bytes_written);
           ~~~~~~~ ^~~~~~~~~~~~~
```

Getting this error on `gem install nio4r` using an Apple M1 computer.

The value of a `long` type is being assigned to an `int` type, which may result in the loss of data. By casting the `bytes_read` and `bytes_written` variable to an `int` type, this will ensure that the `bytes_read` and `bytes_written` value is truncated to fit in the range of an `int` type, and prevent any loss of data, which fixes this error.